### PR TITLE
remove step 7 from pilot team process

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,7 @@ Trust Anchor. The configuration endpoint is determined by concatenating the stri
 same key communicated in the request.
 5. Verify that the Federation Trust Anchor is compliant with all the requirements listed above.
 6. If everything is ok, add the Federation Trust Anchor as a subordinate of the eduGAIN OIDF Pilot Trust Anchor.
-7. Verify that a valid Trust Chain exists between the Federation Trust Anchor and other subordinates of the eduGAIN OIDF Pilot Trust Anchor.
-8. Communicate to the requester that all is good and they've been officially on boarded to the pilot.
+7. Communicate to the requester that all is good and they've been officially on boarded to the pilot.
 
 ### eduGAIN Pilot Entities Configurations
 


### PR DESCRIPTION
I removed step 7 "Verify that a valid Trust Chain exists between the Federation Trust Anchor and other subordinates of the eduGAIN OIDF Pilot Trust Anchor." from the list of things that the pilot team does after a request was submitted.

With our setup this cannot be done. A Trust Chain always goes from one entity A to a Trust Anchor, and from an entity B to a Trust Anchor, it does not go from A to B. Therefore, there cannot be a valid trust chain between the federation trust anchor and other subordinates of the edugain pilot trust anchor.