### PR TITLE
feat: Update shebang in start/stop scripts to work across environments 

### DIFF
--- a/pilot/start-all.sh
+++ b/pilot/start-all.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 cd caddy && docker compose up -d && cd ..
 cd ta && docker compose up -d && cd ..

--- a/pilot/stop-all.sh
+++ b/pilot/stop-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cd rp1 && docker compose down && cd ..
 cd ia1 && docker compose down && cd ..


### PR DESCRIPTION
Update shebang lines from `#!/bin/bash` to `#!/usr/bin/env bash` for improved portability across environments, in my case MacOS where it throws:

```shell
edugain-oidf-pilot/pilot (main) ~ ./start-all.sh
zsh: ./start-all.sh: bad interpreter: /usr/bin/bash: no such file or directory
```

Note: `#!/bin/bash` does work for me, however this would break `#!/usr/bin/bash` for others, so using an env approach seems like a reasonable middle ground